### PR TITLE
Add auto-generation of TOC

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# See GitHub documentation:
+# https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo.
+* @pmalirz

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,6 +5,7 @@ on:
 jobs:
   awesome-lint:
     runs-on: ubuntu-latest
+    needs: generateTOC
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/toc.yaml
+++ b/.github/workflows/toc.yaml
@@ -15,3 +15,5 @@ jobs:
     steps:
       - name: TOC Generator
         uses: technote-space/toc-generator@v4
+        with:
+          TOC_TITLE: ''

--- a/.github/workflows/toc.yaml
+++ b/.github/workflows/toc.yaml
@@ -1,0 +1,17 @@
+name: TOC Generator
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    paths:
+      - "README.md"
+
+jobs:
+  generateTOC:
+    name: TOC Generator
+    runs-on: ubuntu-latest
+    steps:
+      - name: TOC Generator
+        uses: technote-space/toc-generator@v4

--- a/README.md
+++ b/README.md
@@ -13,16 +13,8 @@ A curated list of awesome **[InnerSource](https://innersourcecommons.org/)** res
 <!--lint ignore double-link-->
 This [awesome](https://github.com/sindresorhus/awesome) repository is maintained by the [InnerSource Commons Community](https://innersourcecommons.org/).
 
-## Contents
-
-- [Books](#books)
-- [Tools and Applications](#tools-and-applications)
-- [Articles and Videos](#articles-and-videos)
-  - [About InnerSource](#about-innersource)
-  - [Culture](#culture)
-  - [DevOps](#devops)
-  - [Metrics, Incentives, ROI, KPI](#metrics-incentives-roi-kpi)
-- [Adopters](#adopters)
+<!-- START doctoc -->
+<!-- END doctoc -->
 
 ## Books
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,20 @@ A curated list of awesome **[InnerSource](https://innersourcecommons.org/)** res
 <!--lint ignore double-link-->
 This [awesome](https://github.com/sindresorhus/awesome) repository is maintained by the [InnerSource Commons Community](https://innersourcecommons.org/).
 
-<!-- START doctoc -->
-<!-- END doctoc -->
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**
+
+- [Books](#books)
+- [Tools and Applications](#tools-and-applications)
+- [Articles and Videos](#articles-and-videos)
+  - [About InnerSource](#about-innersource)
+  - [Culture](#culture)
+  - [DevOps](#devops)
+  - [Metrics, Incentives, ROI, KPI](#metrics-incentives-roi-kpi)
+- [Adopters](#adopters)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Books
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ This [awesome](https://github.com/sindresorhus/awesome) repository is maintained
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Books](#books)
+- [Tools and Applications](#tools-and-applications)
+- [Articles and Videos](#articles-and-videos)
+  - [About InnerSource](#about-innersource)
+  - [Culture](#culture)
+  - [DevOps](#devops)
+  - [Metrics, Incentives, ROI, KPI](#metrics-incentives-roi-kpi)
+- [Adopters](#adopters)
+
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Books

--- a/README.md
+++ b/README.md
@@ -13,19 +13,10 @@ A curated list of awesome **[InnerSource](https://innersourcecommons.org/)** res
 <!--lint ignore double-link-->
 This [awesome](https://github.com/sindresorhus/awesome) repository is maintained by the [InnerSource Commons Community](https://innersourcecommons.org/).
 
+## Contents
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**
-
-- [Books](#books)
-- [Tools and Applications](#tools-and-applications)
-- [Articles and Videos](#articles-and-videos)
-  - [About InnerSource](#about-innersource)
-  - [Culture](#culture)
-  - [DevOps](#devops)
-  - [Metrics, Incentives, ROI, KPI](#metrics-incentives-roi-kpi)
-- [Adopters](#adopters)
-
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Books


### PR DESCRIPTION
Adding a GHA to automatically update the Table of Contents (TOC).

While I suspect that the sections we use in the README won't change that often, it is nice to automatically keep the ToC up-to-date. That way contributors don't have to know anything about this.

Also add `@pmarliz` as CODEOWNER, as he is the de-facto-owner of this repo at the moment anyways :)