### PR TITLE
Add page exclusive for pt-br content

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A curated list of awesome **[InnerSource](https://innersourcecommons.org/)** res
 [InnerSource](https://innersourcecommons.org/) is a software development strategy that applies open source best practices to proprietary code. InnerSource can help establish an open source culture within an organization while retaining software for internal use. Teams use InnerSource to increase visibility, strengthen collaboration and break down silos. Through the set of practices, InnerSource helps companies to simplify, standardize and make cost savings globally and across departments.
 
 <!--lint ignore double-link-->
-This [awesome](https://github.com/sindresorhus/awesome) repository is maintained by the [InnerSource Commons Community](https://innersourcecommons.org/).
+This [awesome](https://github.com/InnerSourceCommons/awesome-innersource) repository is maintained by the [InnerSource Commons Community](https://innersourcecommons.org/).
 
 ### Contents available in:
  - [Brazilian portuguese](/content/pt-br/README.md)

--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ A curated list of awesome **[InnerSource](https://innersourcecommons.org/)** res
 <!--lint ignore double-link-->
 This [awesome](https://github.com/InnerSourceCommons/awesome-innersource) repository is maintained by the [InnerSource Commons Community](https://innersourcecommons.org/).
 
-### Contents available in:
+### Available languages
 
- - [Brazilian portuguese](README.pt-br.md)
- - [English](#contents)
+- [Brazilian portuguese](README.pt-br.md)
+- [English](#contents)
 
+<!--lint ignore awesome-toc-->
 ## Contents
 
 - [Books](#books)
@@ -41,7 +42,7 @@ This [awesome](https://github.com/InnerSourceCommons/awesome-innersource) reposi
 ## Tools and Applications
 
 - [Backstage](https://backstage.io/) - An open platform for building developer portals. Realization of the [InnerSource Portal Pattern](https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/main/patterns/2-structured/innersource-portal.md).
-- [gilda](https://gitlab.com/gilda2/gilda) - InnerSource web gamifiaction platform for gitlab.
+- [gilda](https://gitlab.com/gilda2/gilda) - InnerSource web gamifiaction platform for GitLab.
 - [Project Portal for InnerSource by SAP](https://github.com/SAP/project-portal-for-innersource) - A reference implementation to list all InnerSource projects of a company in an interactive and easy to use way.
 
 ## Articles and Videos

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ A curated list of awesome **[InnerSource](https://innersourcecommons.org/)** res
 <!--lint ignore double-link-->
 This [awesome](https://github.com/sindresorhus/awesome) repository is maintained by the [InnerSource Commons Community](https://innersourcecommons.org/).
 
+### Contents available in:
+ - [Brazilian portuguese](/content/pt-br/README.md)
+ - [English](#contents)
+
 ## Contents
 
 - [Books](#books)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A curated list of awesome **[InnerSource](https://innersourcecommons.org/)** res
 This [awesome](https://github.com/InnerSourceCommons/awesome-innersource) repository is maintained by the [InnerSource Commons Community](https://innersourcecommons.org/).
 
 ### Contents available in:
+
  - [Brazilian portuguese](README.pt-br.md)
  - [English](#contents)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A curated list of awesome **[InnerSource](https://innersourcecommons.org/)** res
 This [awesome](https://github.com/InnerSourceCommons/awesome-innersource) repository is maintained by the [InnerSource Commons Community](https://innersourcecommons.org/).
 
 ### Contents available in:
- - [Brazilian portuguese](/content/pt-br/README.md)
+ - [Brazilian portuguese](README.pt-br.md)
  - [English](#contents)
 
 ## Contents

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -1,6 +1,6 @@
 Uma lista de recursos incríveis sobre **[InnerSource](https://innersourcecommons.org/)** (livros, artigos, blogs, projetos e mais).  
 
-> If you do not speak portuguese, check [other languages availables](../../README.md#contents)
+> If you do not speak portuguese, check [other languages availables](./README.md#contents)
 
 <!--lint ignore double-link-->
 [<img src="../../assets/images/innersource-logo.png" align="right" width="100" alt="InnerSource Commons">](https://innersourcecommons.org/)

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -11,7 +11,6 @@ Uma lista de recursos incríveis sobre **[InnerSource](https://innersourcecommon
 <!--lint ignore double-link-->
 Esse [incrível](https://github.com/InnerSourceCommons/awesome-innersource) (_awsome_) repositório é nabtudi pela [Comunidade InnerSource Commons](https://innersourcecommons.org/).
 
-
 ## Conteúdo
 
 - [Livros](#livros)

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -1,6 +1,6 @@
 Uma lista de recursos incríveis sobre **[InnerSource](https://innersourcecommons.org/)** (livros, artigos, blogs, projetos e mais).  
 
-> If you do not speak portuguese, check [other languages availables](./README.md#contents)
+> If you do not speak Portuguese, check [other languages available](./README.md#contents)
 
 <!--lint ignore double-link-->
 [<img src="../../assets/images/innersource-logo.png" align="right" width="100" alt="InnerSource Commons">](https://innersourcecommons.org/)

--- a/content/pt-br/README.md
+++ b/content/pt-br/README.md
@@ -1,0 +1,32 @@
+Uma lista de recursos incríveis sobre **[InnerSource](https://innersourcecommons.org/)** (livros, artigos, blogs, projetos e mais).  
+
+> If you do not speak portuguese, check [other languages availables](../../README.md)
+
+<!--lint ignore double-link-->
+[<img src="../../assets/images/innersource-logo.png" align="right" width="100" alt="InnerSource Commons">](https://innersourcecommons.org/)
+
+<!--lint ignore double-link-->
+[InnerSource](https://innersourcecommons.org/) é uma estratégia de desenvolvimento de software que aplica melhores práticas de open source em código proprietário. InnerSource pode ajudar a estabelecer uma cultura open source na organização enquanto retém o código para uso interno. Times usam InnerSource para aumentar a visibilidade, fortalecer colaboração e quebrar silos. Através de um conjunto de práticas, InnerSource ajuda empresas a simplificar, padronizar e reduzir custos globalmente e entre departamentos.
+
+<!--lint ignore double-link-->
+Esse [incrível](https://github.com/InnerSourceCommons/awesome-innersource) (_awsome_) repositório é nabtudi pela [Comunidade InnerSource Commons](https://innersourcecommons.org/).
+
+
+## Conteúdo
+
+- [Livros](#livros)
+- [Artigos](#artigos)
+- [Vídeos](#videos)
+
+## Livros
+
+## Artigos
+
+## Vídeos
+
+ - [InnerSource: desenvolvimento colaborativo como alavanca em Tecnologia](https://www.youtube.com/watch?v=YFEnvDBuzl4) 
+
+### Sobre InnerSource
+
+<!--lint ignore double-link-->
+- [Site InnerSource Commons](https://innersourcecommons.org/pt-br/) - A InnerSource Commons é a maior comunidade mundial de praticantes de InnerSource. É dedicada à criação e compartilhamento de conhecimento sobre InnerSource, o uso das melhores práticas de código aberto para o desenvolvimento de software dentro dos limites de uma organização.

--- a/content/pt-br/README.md
+++ b/content/pt-br/README.md
@@ -1,6 +1,6 @@
 Uma lista de recursos incríveis sobre **[InnerSource](https://innersourcecommons.org/)** (livros, artigos, blogs, projetos e mais).  
 
-> If you do not speak portuguese, check [other languages availables](../../README.md)
+> If you do not speak portuguese, check [other languages availables](../../README.md#contents)
 
 <!--lint ignore double-link-->
 [<img src="../../assets/images/innersource-logo.png" align="right" width="100" alt="InnerSource Commons">](https://innersourcecommons.org/)


### PR DESCRIPTION
Propose a pattern to create pages with curated content in other languages than english.

- Create folder structure to handle languages: `/content/<language>`
- Add a index to all available language content (I opted to add english as an option and link to the main content, to be explicit)
- Fix the link in the main page to the repository, it was pointing to a totally different repository (probably the one that was inspiration for this one).
